### PR TITLE
feat: force clean

### DIFF
--- a/integration/index.2.test.js
+++ b/integration/index.2.test.js
@@ -19,7 +19,7 @@ describe('test/index.v2.test.js', () => {
   let cwd;
 
   afterEach(async () => {
-    await clean(cwd);
+    await clean({ cwd });
     if (process.platform === 'darwin') {
       try {
         await forceExitDaemon();

--- a/integration/index.test.js
+++ b/integration/index.test.js
@@ -16,7 +16,9 @@ const {
 describe('test/tnpm-install-rapid.test.js', () => {
   let fixture;
   afterEach(async () => {
-    await clean(fixture);
+    await clean({
+      cwd: fixture,
+    });
     if (process.platform === 'darwin') {
       await forceExitDaemon();
     } else {

--- a/integration/workspaces.test.js
+++ b/integration/workspaces.test.js
@@ -19,6 +19,7 @@ describe('test/workspaces.test.js', () => {
     cwd = path.join(__dirname, './fixtures/workspaces');
     await clean(cwd);
     await install({
+      nydusMode: 'FUSE',
       cwd,
       pkg: require(path.join(cwd, 'package.json')),
       depsTreePath: path.join(cwd, 'package-lock.json'),

--- a/integration/workspaces.test.js
+++ b/integration/workspaces.test.js
@@ -17,7 +17,10 @@ describe('test/workspaces.test.js', () => {
 
   it('should install lodash successfully', async () => {
     cwd = path.join(__dirname, './fixtures/workspaces');
-    await clean(cwd);
+    await clean({
+      cwd,
+      force: true,
+    });
     await install({
       nydusMode: 'FUSE',
       cwd,
@@ -35,7 +38,10 @@ describe('test/workspaces.test.js', () => {
       assert(lodash1.version.startsWith('1.'));
       assert(lodash2.version.startsWith('2.'));
     } finally {
-      await clean(cwd);
+      await clean({
+        cwd,
+        force: true,
+      });
       if (process.platform === 'darwin') {
         await forceExitDaemon();
       } else {

--- a/packages/cli/bin/rapid.js
+++ b/packages/cli/bin/rapid.js
@@ -4,12 +4,13 @@
 
 const { clean, install, list } = require('../lib/index.js');
 const yargs = require('yargs');
-const { NpmFsMode } = require('../lib/constants.js');
+const { NpmFsMode, NYDUS_TYPE } = require('../lib/constants.js');
 const util = require('../lib/util');
 
 yargs
   .command({
     command: 'install',
+    aliases: [ 'i', 'ii' ],
     describe: 'Install dependencies',
     builder: yargs => {
       return yargs
@@ -30,10 +31,12 @@ yargs
       const pkgRes = await util.readPkgJSON();
       const pkg = pkgRes?.pkg || {};
 
+      await util.shouldFuseSupport();
       await install({
         cwd,
         pkg,
         mode,
+        nydusMode: NYDUS_TYPE.FUSE,
         ignoreScripts,
       });
 
@@ -44,16 +47,17 @@ yargs
   })
   .command({
     command: 'clean',
+    aliases: [ 'c', 'unmount', 'uninstall' ],
     describe: 'Clean up the project',
     handler: async () => {
       const cwd = process.cwd();
-      await clean(cwd);
-
+      await clean({ nydusMode: NYDUS_TYPE.FUSE, cwd, force: false });
       console.log('[rapid] clean finished');
     },
   })
   .command({
     command: 'list',
+    aliases: 'l',
     describe: 'List rapid mount info',
     handler: async () => {
       const cwd = process.cwd();

--- a/packages/cli/bin/rapid.js
+++ b/packages/cli/bin/rapid.js
@@ -6,6 +6,7 @@ const { clean, install, list } = require('../lib/index.js');
 const yargs = require('yargs');
 const { NpmFsMode, NYDUS_TYPE } = require('../lib/constants.js');
 const util = require('../lib/util');
+const path = require('node:path');
 
 yargs
   .command({
@@ -46,11 +47,14 @@ yargs
     },
   })
   .command({
-    command: 'clean',
+    command: 'clean [path]',
     aliases: [ 'c', 'unmount', 'uninstall' ],
     describe: 'Clean up the project',
-    handler: async () => {
-      const cwd = process.cwd();
+    handler: async argv => {
+      let cwd = argv.path || process.cwd();
+      if (cwd.endsWith('node_modules') || cwd.endsWith('node_modules/')) {
+        cwd = path.dirname(cwd);
+      }
       await clean({ nydusMode: NYDUS_TYPE.FUSE, cwd, force: false });
       console.log('[rapid] clean finished');
     },

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -8,6 +8,7 @@ const Scripts = require('./scripts').Scripts;
 const {
   nydusdConfigFile,
   tarBucketsDir,
+  NYDUS_TYPE,
 } = require('./constants');
 const util = require('./util');
 const nydusd = require('./nydusd');
@@ -66,7 +67,7 @@ exports.install = async options => {
   console.timeEnd('[rapid] run lifecycle scripts');
 };
 
-exports.clean = async function clean({ nydusMode, cwd, force }) {
+exports.clean = async function clean({ nydusMode = NYDUS_TYPE.FUSE, cwd, force }) {
   const listInfo = await util.listMountInfo();
   if (!listInfo.length) {
     console.log('[rapid] no mount info found.');

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -8,7 +8,6 @@ const Scripts = require('./scripts').Scripts;
 const {
   nydusdConfigFile,
   tarBucketsDir,
-  NYDUS_TYPE,
 } = require('./constants');
 const util = require('./util');
 const nydusd = require('./nydusd');

--- a/packages/cli/lib/nydusd/fuse_mode.js
+++ b/packages/cli/lib/nydusd/fuse_mode.js
@@ -13,6 +13,7 @@ const {
   wrapSudo,
   getWorkdir,
   getAllPkgPaths,
+  safeExeca,
 } = require('../util');
 const nydusdApi = require('./nydusd_api');
 
@@ -108,8 +109,8 @@ async function endNydusFs(cwd, pkg, force = false) {
     );
     if (os.type() === 'Darwin') {
       console.log(`[rapid] ${umountCmd} ${nodeModulesDir}`);
-      await execa.command(`${umountCmd} ${nodeModulesDir}`);
-      await execa.command(`hdiutil detach -force ${overlay}`);
+      await safeExeca(`umount ${nodeModulesDir}`, force ? `umount -f ${nodeModulesDir}` : '');
+      await safeExeca(`hdiutil detach ${overlay}`, force ? `hdiutil detach -force ${overlay}` : '');
     } else {
       await execa.command(wrapSudo(`${umountCmd} ${nodeModulesDir}`));
       await execa.command(wrapSudo(`${umountCmd} ${overlay}`));

--- a/packages/cli/lib/nydusd/fuse_mode.js
+++ b/packages/cli/lib/nydusd/fuse_mode.js
@@ -109,7 +109,7 @@ async function endNydusFs(cwd, pkg, force = false) {
     if (os.type() === 'Darwin') {
       console.log(`[rapid] ${umountCmd} ${nodeModulesDir}`);
       await execa.command(`${umountCmd} ${nodeModulesDir}`);
-      await execa.command(`${umountCmd} ${overlay}`);
+      await execa.command(`hdiutil detach -force ${overlay}`);
     } else {
       await execa.command(wrapSudo(`${umountCmd} ${nodeModulesDir}`));
       await execa.command(wrapSudo(`${umountCmd} ${overlay}`));

--- a/packages/cli/lib/nydusd/fuse_mode.js
+++ b/packages/cli/lib/nydusd/fuse_mode.js
@@ -98,23 +98,21 @@ ${nodeModulesDir}`;
   }
 }
 
-async function endNydusFs(cwd, pkg) {
+async function endNydusFs(cwd, pkg, force = false) {
   const allPkgs = await getAllPkgPaths(cwd, pkg);
+  const umountCmd = force ? 'umount -f' : 'umount';
   for (const pkgPath of allPkgs) {
-    const {
-      dirname,
-      overlay,
-      baseDir,
-      nodeModulesDir,
-    } = await getWorkdir(cwd, pkgPath);
+    const { dirname, overlay, baseDir, nodeModulesDir } = await getWorkdir(
+      cwd,
+      pkgPath
+    );
     if (os.type() === 'Darwin') {
-      console.log(`[rapid] umount ${nodeModulesDir}`);
-      await execa.command(`umount ${nodeModulesDir}`);
-      // hdiutil detach
-      await execa.command(`hdiutil detach ${overlay}`);
+      console.log(`[rapid] ${umountCmd} ${nodeModulesDir}`);
+      await execa.command(`${umountCmd} ${nodeModulesDir}`);
+      await execa.command(`${umountCmd} ${overlay}`);
     } else {
-      await execa.command(wrapSudo(`umount ${nodeModulesDir}`));
-      await execa.command(wrapSudo(`umount ${overlay}`));
+      await execa.command(wrapSudo(`${umountCmd} ${nodeModulesDir}`));
+      await execa.command(wrapSudo(`${umountCmd} ${overlay}`));
     }
     await nydusdApi.umount(`/${dirname}`);
     // 清除 nydus 相关目录

--- a/packages/cli/lib/nydusd/index.js
+++ b/packages/cli/lib/nydusd/index.js
@@ -37,14 +37,14 @@ exports.startNydusFs = async function(mode, cwd, pkg) {
   await impl.start(cwd, pkg);
 };
 
-exports.endNydusFs = async function(mode, cwd, pkg) {
+exports.endNydusFs = async function(mode, cwd, pkg, force) {
   if (!mode || mode === NYDUS_TYPE.NATIVE) {
     console.log('[rapid] nydusd is not running, skip clean');
     return;
   }
   const impl = fsImplMap[mode];
   assert(impl, `can not find fs impl for mode: ${mode}`);
-  await impl.end(cwd, pkg);
+  await impl.end(cwd, pkg, force);
 };
 
 exports.getNydusMode = async function(cwd) {

--- a/packages/cli/lib/nydusd/nydusd_api.js
+++ b/packages/cli/lib/nydusd/nydusd_api.js
@@ -159,7 +159,15 @@ async function forceExitDaemon() {
     await execa.command('killall -9 nydusd');
   } catch (e) {
     // ignore, nydusd quits with error, but it's ok
-    e.message = 'exit nydusd faield: ' + e.message;
+    e.message = 'umount nydusd mnt failed: ' + e.message;
+    console.warn(e);
+  }
+
+  try {
+    await execa.command('killall -9 nydusd');
+  } catch (e) {
+    // ignore, nydusd quits with error, but it's ok
+    e.message = 'exit nydusd failed: ' + e.message;
     console.warn(e);
   }
 }

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -54,6 +54,19 @@ function wrapSudo(shScript) {
   return `sudo ${shScript}`;
 }
 
+async function safeExeca(command, fallback) {
+  try {
+    await execa.command(command);
+  } catch (e) {
+    console.warn(`[rapid] ${command} error: `, e);
+    try {
+      fallback && (await execa.command(fallback));
+    } catch (e) {
+      // ignore
+    }
+  }
+}
+
 // 需要手动写入，保证 path 路径符合预期
 async function createNydusdConfigFile(path) {
   await fs.writeFile(path, JSON.stringify({
@@ -617,3 +630,4 @@ exports.isFlattenPackage = isFlattenPackage;
 exports.resolveBinMap = resolveBinMap;
 exports.getFileEntryMode = getFileEntryMode;
 exports.getEnv = getEnv;
+exports.safeExeca = safeExeca;


### PR DESCRIPTION
> #38 二次安装时，判断当前是否有对应挂载点
* rapid list 不再判断 nydusd 启动状态
* clean 方法添加 force 参数，开启时执行 `umount -f`
* 新增 clean [path] 参数
* ~~hdiutil detach 统一使用 umount 实现~~
