### PR TITLE
fix: ensure access

### DIFF
--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -60,15 +60,10 @@ exports.install = async options => {
   await nydusd.startNydusFs(options.nydusMode, options.cwd, options.pkg);
 
 
-  console.time('[rapid] wait for access');
   await util.ensureAccess(options.cwd, packageLock);
-  console.timeEnd('[rapid] wait for access');
 
   // 存放原始依赖树，用于 npm 二次更新依赖
-  await fs.writeFile(
-    path.join(options.cwd, 'node_modules', '.package-lock.json'),
-    JSON.stringify(packageLock, null, 2)
-  );
+  await util.storePackageLock(options.cwd, packageLock);
 
   console.time('[rapid] run lifecycle scripts');
   await options.scripts.runLifecycleScripts(mirrorConfig);

--- a/packages/cli/lib/index.js
+++ b/packages/cli/lib/index.js
@@ -59,6 +59,17 @@ exports.install = async options => {
   assert(Object.keys(packageLock).length, '[rapid] depsJSON invalid.');
   await nydusd.startNydusFs(options.nydusMode, options.cwd, options.pkg);
 
+
+  console.time('[rapid] wait for access');
+  await util.ensureAccess(options.cwd, packageLock);
+  console.timeEnd('[rapid] wait for access');
+
+  // 存放原始依赖树，用于 npm 二次更新依赖
+  await fs.writeFile(
+    path.join(options.cwd, 'node_modules', '.package-lock.json'),
+    JSON.stringify(packageLock, null, 2)
+  );
+
   console.time('[rapid] run lifecycle scripts');
   await options.scripts.runLifecycleScripts(mirrorConfig);
   console.timeEnd('[rapid] run lifecycle scripts');

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -434,6 +434,43 @@ function validDep(pkg, productionMode, arch, platform) {
 
 }
 
+exports.ensureAccess = async function ensureAccess(cwd, packageLock) {
+  let access = false;
+  let targetPath;
+
+  for (const [ pkgPath, pkgItem ] of Object.entries(packageLock.packages)) {
+    if (pkgPath.startsWith('node_modules') && !pkgItem.optional) {
+      targetPath = pkgPath;
+      break;
+    }
+  }
+
+  // 如果没有找到合适的检测点，直接返回
+  if (!targetPath) {
+    return;
+  }
+
+  let retry = 0;
+
+  // 如果找到了检测点，但是检测点不存在，等待检测点创建
+  while (!access) {
+    try {
+      await fs.access(path.join(cwd, targetPath));
+      access = true;
+    } catch (e) {
+      retry++;
+      console.log(
+        `[rapid] still waiting for access ${targetPath} retry after 50ms, retry count: ${retry}`
+      );
+      if (retry > 40) {
+        console.error(`[rapid] wait for access ${targetPath} timeout`);
+        throw e;
+      }
+      await this.sleep(50);
+    }
+  }
+};
+
 exports.getAllPkgPaths = async function getAllPkgPaths(cwd, pkg) {
   const workspaces = await exports.getWorkspaces(cwd, pkg);
   const allPkgs = Object.values(workspaces);


### PR DESCRIPTION
> 重新添加 `ensureAccess` 流程，添加 `.package-lock.json` 和 npm 保持一致
* 解决部分场景下，mountOverlay 后 文件系统仍无法访问 🤡
* 在 `node_modules` 下存放 ./package-lock.json，由于文件本身没有下载功能，不在 npmFs 中映射。