### PR TITLE
fix: node gyp scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,6 @@ bindings/*/index.node
 .idea
 packages/cli/test/fixtures/project-scripts/apps/a/1
 packages/downloader/test/nginx.conf
-package-lock.json
 
 # napi-rs generate wrong type ignore for tmp
 packages/binding/index.d.ts

--- a/integration/fixtures/gyp/package-lock.json
+++ b/integration/fixtures/gyp/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "gyp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "fsevents": "^1.2.13"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.antgroup-inc.cn/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.antgroup-inc.cn/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.antgroup-inc.cn/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+      "hasInstallScript": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.antgroup-inc.cn/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
+    }
+  }
+}

--- a/integration/fixtures/gyp/package.json
+++ b/integration/fixtures/gyp/package.json
@@ -1,0 +1,6 @@
+{
+  "repository": "git@github.com:cnpm/rapid.git",
+  "dependencies": {
+    "fsevents": "^1.2.13"
+  }
+}

--- a/integration/index.2.test.js
+++ b/integration/index.2.test.js
@@ -57,32 +57,6 @@ describe('test/index.v2.test.js', () => {
     }
   });
 
-  describe('node gyp', async () => {
-    it('should support node-gyp for npminstall', async () => {
-      cwd = path.join(__dirname, './fixtures/gyp');
-      await coffee
-        .fork(rapid, [ 'install', '--by=npminstall' ], {
-          cwd,
-        })
-        .debug()
-        .expect('code', 0)
-        .expect('stdout', /CXX\(target\) Release\/obj.target\/fse\/fsevents\.o/)
-        .end();
-    });
-
-    it('should support node-gyp for npm mode', async () => {
-      cwd = path.join(__dirname, './fixtures/gyp');
-      await coffee
-        .fork(rapid, [ 'install', '--by=npm' ], {
-          cwd,
-        })
-        .debug()
-        .expect('code', 0)
-        .expect('stdout', /CXX\(target\) Release\/obj.target\/fse\/fsevents\.o/)
-        .end();
-    });
-  });
-
   describe('INIT_CWD', async () => {
     it('should set INIT_CWD', async () => {
       cwd = path.join(__dirname, './fixtures/init-cwd');
@@ -228,6 +202,5 @@ describe('test/index.v2.test.js', () => {
     const res = await execa.command('mount', { stdio: 'pipe' });
     assert(res.stdout.indexOf('integration/fixtures/esbuild/node_modules') === res.stdout.lastIndexOf('integration/fixtures/esbuild/node_modules'));
   });
-
 
 });

--- a/integration/index.2.test.js
+++ b/integration/index.2.test.js
@@ -57,6 +57,32 @@ describe('test/index.v2.test.js', () => {
     }
   });
 
+  describe('node gyp', async () => {
+    it('should support node-gyp for npminstall', async () => {
+      cwd = path.join(__dirname, './fixtures/gyp');
+      await coffee
+        .fork(rapid, [ 'install', '--by=npminstall' ], {
+          cwd,
+        })
+        .debug()
+        .expect('code', 0)
+        .expect('stdout', /CXX\(target\) Release\/obj.target\/fse\/fsevents\.o/)
+        .end();
+    });
+
+    it('should support node-gyp for npm mode', async () => {
+      cwd = path.join(__dirname, './fixtures/gyp');
+      await coffee
+        .fork(rapid, [ 'install', '--by=npm' ], {
+          cwd,
+        })
+        .debug()
+        .expect('code', 0)
+        .expect('stdout', /CXX\(target\) Release\/obj.target\/fse\/fsevents\.o/)
+        .end();
+    });
+  });
+
   describe('INIT_CWD', async () => {
     it('should set INIT_CWD', async () => {
       cwd = path.join(__dirname, './fixtures/init-cwd');
@@ -171,7 +197,6 @@ describe('test/index.v2.test.js', () => {
   it('should auto clean when reinstall', async () => {
     cwd = path.join(__dirname, './fixtures/esbuild');
 
-
     await coffee
       .fork(rapid, [
         'install',
@@ -203,4 +228,6 @@ describe('test/index.v2.test.js', () => {
     const res = await execa.command('mount', { stdio: 'pipe' });
     assert(res.stdout.indexOf('integration/fixtures/esbuild/node_modules') === res.stdout.lastIndexOf('integration/fixtures/esbuild/node_modules'));
   });
+
+
 });

--- a/packages/cli/lib/node-gyp-bin/node-gyp
+++ b/packages/cli/lib/node-gyp-bin/node-gyp
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+node "`dirname "$0"`/node-gyp.js" "$@"

--- a/packages/cli/lib/node-gyp-bin/node-gyp.cmd
+++ b/packages/cli/lib/node-gyp-bin/node-gyp.cmd
@@ -1,0 +1,1 @@
+node "%~dp0\node-gyp.js" %*

--- a/packages/cli/lib/node-gyp-bin/node-gyp.js
+++ b/packages/cli/lib/node-gyp-bin/node-gyp.js
@@ -1,0 +1,3 @@
+'use strict';
+
+return require('node-gyp/bin/node-gyp.js');

--- a/packages/cli/lib/util.js
+++ b/packages/cli/lib/util.js
@@ -534,7 +534,7 @@ exports.runScript = async (pkgDir, script, options) => {
     // ignore error
   }
   env.PATH = [
-    path.join(__dirname, '../node-gyp-bin'),
+    path.join(__dirname, './node-gyp-bin'),
     path.join(options.cwd, 'node_modules', '.bin'),
     path.join(pkgDir, 'node_modules', '.bin'),
     process.env.PATH,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,8 @@
     "semver": "^7.3.8",
     "urllib": "^3.16.1",
     "yargs": "^17.7.2",
-    "yargs-parser": "^9.0.2"
+    "yargs-parser": "^9.0.2",
+    "node-gyp": "^9.0.0"
   },
   "homepage": "https://github.com/cnpm/rapid",
   "repository": {


### PR DESCRIPTION
* 修复通过 node-gyp 进行编译的包 postinstall 异常
* 添加 `node-gyp-bin` 相关定义，逻辑参照: https://github.com/cnpm/npminstall/blob/master/lib/utils.js#L238